### PR TITLE
Add ability to instruct pushy to ignore certain elements

### DIFF
--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -116,6 +116,9 @@
                                  (not (.-shiftKey e))
                                  ;; Bypass if target = _blank
                                  (not (get #{"_blank" "_self"} (.getAttribute el "target")))
+                                 ;; Bypass if explicitly instructed to ignore this element
+                                 (or (not (.hasAttribute el "data-pushy-ignore"))
+                                     (= (.getAttribute el "data-pushy-ignore") "false"))
                                  ;; Bypass dispatch if middle click
                                  (not= 1 (.-button e)))
                         (let [next-token (get-token-from-uri uri)]


### PR DESCRIPTION
In a Reagent project, I need to be able to handle clicks on an anchor differently depending upon whether the resource at the anchor's href is "locked". This change would allow me to change some code that looks like this:

``` clojure
[:a {:href "#"
     :on-click (fn [e]
                 (if lock
                   (do
                     (.preventDefault e)
                     (dispatch
                      [:lock/show-remittance-dialog (:entity lock)]))
                   (history/go!
                    (routes/url-for :resource entity))))}
 "Edit"]
```

into code that looks like this:

``` clojure
[:a {:href (routes/url-for :resource entity)
     :data-pushy-ignore (boolean lock)
     :on-click (fn [e]
                 (when lock
                   (.preventDefault e)
                   (dispatch
                    [:lock/show-remittance-dialog (:entity lock)])))}
 "Edit"]
```

I think the latter is superior because users can right click + open in new tab. I also think it reads a bit better.
