### PR TITLE
Added fragments to tokens.

### DIFF
--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -26,7 +26,7 @@
 (defn- set-retrieve-token! [t]
   (set! (.. t -retrieveToken)
         (fn [path-prefix location]
-          (str (.-pathname location) (.-search location))))
+          (str (.-pathname location) (.-search location) (.-hash location))))
   t)
 
 (defn- set-create-url! [t]
@@ -54,11 +54,17 @@
            (some? (re-matches (re-pattern (str "^" (.-origin js/location) ".*$"))
                               (str uri))))))
 
-(defn- get-token-from-uri [uri]
+(defn- get-token-from-uri
+  "Returns /path?query#fragment from uri"
+  [uri]
   (let [path (.getPath uri)
-        query (.getQuery uri)]
-    ;; Include query string in token
-    (if (empty? query) path (str path "?" query))))
+        query (.getQuery uri)
+        fragment (.getFragment uri)]
+    (str path
+         (when (seq query)
+           (str "?" query))
+         (when (seq fragment)
+           (str "#" fragment)))))
 
 (defn pushy
   "Takes in three functions:


### PR DESCRIPTION
Previously the URL fragment wasn't being set as part of the token, so links such as `<a href="#section-1">link</a>` would get completely ignored. 

Similarly if there was a fragment, it would be stripped out on navigating back since the tokens in the stack didn't know about it. 

I'm not sure if this was intentional, or just a vestige of using the hash for history in old browsers, but pushy is configured not to use the fragment so I can't see a reason not to use it as it was originally intended. In any event it's been useful for me.

Note that the `preventDefault` on L133 prevents the browser from jumping to the corresponding DOM element when there's a fragment, but it's simple enough to do that in your `dispatch-fn`. You also need to listen for the `popstate` event to jump on back. 

I couldn't think of a way to allow the browser to do its thing with the fragment without getting stuck in an infinite loop of navigation. I don't have a lot of experience with client side javascript, so it could very well be something obvious I'm missing. If you have an idea, I'd be happy to hear it. 
