### PR TITLE
add recur for other attrs than href

### DIFF
--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -11,9 +11,9 @@
   (events/listen js/document "click" funk))
 
 (defn- recur-attr
-  "Traverses up the DOM tree and returns the first node that contains a href, action or formaction attr"
+  "Traverses up the DOM tree and returns the first node that contains a href, action or formAction attr"
   [target]
-  (if (some #(goog.object/get target %) #{"href" "action" "formaction"})
+  (if (some #(goog.object/get target %) #{"href" "formAction"})
     target
     (when (.-parentNode target)
       (recur-attr (.-parentNode target)))))
@@ -106,7 +106,7 @@
                (on-click
                 (fn [e]
                   (when-let [el (recur-attr (-> e .-target))]
-                    (let [uri (.parse Uri (.-href el))]
+                    (let [uri (.parse Uri (some #(goog.object/get el %) #{"href" "formAction"}))]
                       ;; Proceed if `identity-fn` returns a value and
                       ;; the user did not trigger the event via one of the
                       ;; keys we should bypass

--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -16,8 +16,10 @@
 (defn- recur-href
   "Traverses up the DOM tree and returns the first node that contains a href, action or formAction attr"
   [target]
-  (when (goog.object/get target "href")
-    target))
+  (if (goog.object/get target "href")
+    target
+    (when (.-parentNode target)
+      (recur-href (.-parentNode target)))))
 
 (defn- recur-action
   "Traverses up the DOM tree and returns the first node that contains a href, action or formAction attr"
@@ -147,6 +149,7 @@
 
                             (when (prevent-default-when-no-match? next-token)
                               (.preventDefault e))))))))))
+
         (swap! event-keys conj
                (on-submit
                  (fn [e]
@@ -160,10 +163,10 @@
                                (if-let [title (-> el .-title)]
                                  (set-token! this next-token title)
                                  (set-token! this next-token))
-                               (doto e (.preventDefault) #_(.stopPropagation)))
+                               (.preventDefault e))
 
                              (when (prevent-default-when-no-match? next-token)
-                               (doto e (.preventDefault) #_(.stopPropagation)))))))))))
+                               (.preventDefault e))))))))))
         nil)
 
       (stop! [this]

--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -10,6 +10,14 @@
 (defn- on-click [funk]
   (events/listen js/document "click" funk))
 
+(defn- recur-attr
+  "Traverses up the DOM tree and returns the first node that contains a href, action or formaction attr"
+  [target]
+  (if (some #(goog.object/get target %) #{"href" "action" "formaction"})
+    target
+    (when (.-parentNode target)
+      (recur-attr (.-parentNode target)))))
+
 (defn- update-history! [h]
   (doto h
     (.setUseFragment false)
@@ -97,7 +105,7 @@
         (swap! event-keys conj
                (on-click
                 (fn [e]
-                  (when-let [el (some-> e .-target (.closest "a"))]
+                  (when-let [el (recur-attr (-> e .-target))]
                     (let [uri (.parse Uri (.-href el))]
                       ;; Proceed if `identity-fn` returns a value and
                       ;; the user did not trigger the event via one of the


### PR DESCRIPTION
- Re-introduce recur as `closest` is "only" supported by 78% of browsers
- Let recur capture `formAction` urls on button/input of type submit in order to handle form action for SPAs