### PR TITLE
Pass history event's isNavigation attribute to dispatch-fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kibu/pushy "0.3.8"
+(defproject kibu/pushy "0.3.9-SNAPSHOT"
   :description "HTML5 pushState for Clojurescript"
   :url "https://github.com/kibu-australia/pushy"
   :license {:name "Eclipse Public License"

--- a/src/pushy/core.cljs
+++ b/src/pushy/core.cljs
@@ -88,7 +88,7 @@
                (events/listen history EventType.NAVIGATE
                               (fn [e]
                                 (when-let [match (-> (.-token e) match-fn identity-fn)]
-                                  (dispatch-fn match)))))
+                                  (dispatch-fn match (.-isNavigation e))))))
 
         ;; Dispatch on initialization
         (when-let [match (-> (get-token this) match-fn identity-fn)]


### PR DESCRIPTION
Hi,

Daniel from [WorksHub](https://functional.works-hub.com) here. First, let me express our gratitude for pushy – it powers navigation in our app and is an excellent little piece of software. Many thanks!

We found ourselves needing to determine in our dispatch-fn whether the request comes from a user's on-page action (clicking a link handled by pushy), or from a browser history action (e.g., clicking Back). Turns out that it's hidden in the `isNavigation` property of the Closure Library's `NAVIGATE` event. This PR passes the value of that property as a second argument to dispatch-fn.

Technically, it's an API breaking change (since dispatch-fn is now expected to take two arguments, rather than one), but I don't have a good idea of how to make it more kosher. I'd be happy to discuss this further.